### PR TITLE
Update docker file with pinned version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:latest
+FROM rabbitmq:3.6.8
 
 ENV RABBITMQ_USE_LONGNAME=true \
     AUTOCLUSTER_LOG_LEVEL=debug \


### PR DESCRIPTION
use a pinned version instead of "latest" since the copy target depends on the version number